### PR TITLE
Support regular (non-RGB) LEDs, including an onboard LED

### DIFF
--- a/atmega_duck/led.cpp
+++ b/atmega_duck/led.cpp
@@ -88,9 +88,9 @@ namespace led {
     void setColor(int r, int g, int b) {
       // On unless all colours are below 50 (about 20%)
       if (r > 50 && g > 50 && b > 50) {
-        digitalWrite(LED_PIN, HIGH);
+        digitalWrite(ledPin, HIGH);
       } else {
-        digitalWrite(LED_PIN, LOW);
+        digitalWrite(ledPin, LOW);
       }
     }
 }

--- a/atmega_duck/led.cpp
+++ b/atmega_duck/led.cpp
@@ -82,7 +82,7 @@ namespace led {
     int ledPin = LED_BUILTIN;
   #endif 
     void begin() {
-      pinMode(LED_PIN, OUTPUT);
+      pinMode(ledPin, OUTPUT);
     }
 
     void setColor(int r, int g, int b) {

--- a/atmega_duck/led.cpp
+++ b/atmega_duck/led.cpp
@@ -73,12 +73,25 @@ namespace led {
     }
 }
 
-#else // if defined(NEOPIXEL)
-
+#else // Use onboard LED, or LED_PIN if defined
+#include <Arduino.h>
 namespace led {
-    void begin() {}
+  #if defined(LED_PIN)
+    int ledPin = LED_PIN;
+  #else
+    int ledPin = LED_BUILTIN;
+  #endif 
+    void begin() {
+      pinMode(LED_PIN, OUTPUT);
+    }
 
-    void setColor(int r, int g, int b) {}
+    void setColor(int r, int g, int b) {
+      // On unless all colours are below 50 (about 20%)
+      if (r > 50 && g > 50 && b > 50) {
+        digitalWrite(LED_PIN, HIGH);
+      } else {
+        digitalWrite(LED_PIN, LOW);
+      }
+    }
 }
-
 #endif // if defined(NEOPIXEL)


### PR DESCRIPTION
I didn't want the hassle of dealing with an RGB LED, but I still wanted some way for the script to indicate a status change.

If no RGB LED is configured in config.h a regular single-colour LED will be used to complete 'LED' commands.
If LED_PIN is #defined (config.h) the specified pin will be used. Otherwise LED_BUILTIN will be used.